### PR TITLE
OSGI missing requirement 'javax.transaction.xa'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
     <commons.jira.pid>12310469</commons.jira.pid>
     <commons.pool.version>2.12.0</commons.pool.version>
     <!-- See DBCP-445 and DBCP-454 -->
-    <commons.osgi.import>javax.transaction;version="1.1.0",javax.transaction.xa;version="1.1.0";partial=true;mandatory:=partial,*</commons.osgi.import>
+    <commons.osgi.import>jakarta.transaction;version="2.0.1",*</commons.osgi.import>
     <commons.japicmp.ignoreMissingClasses>true</commons.japicmp.ignoreMissingClasses>
     <!-- Commons Release Plugin -->
     <commons.bc.version>2.12.0</commons.bc.version>


### PR DESCRIPTION
Ahoy, @kevinleturc 👋

This PR fixes an issue with OSGI package wiring caused by an outdated javax.transaction.* package import.

```
missing requirement [org.apache.commons.commons-dbcp2 [94](R 94.0)] osgi.wiring.package; 
(&(osgi.wiring.package=javax.transaction.xa)(version>=1.1.0)(partial=true))]
```